### PR TITLE
fix(db): add CHECK constraints for status, superuser-team, and revocation

### DIFF
--- a/migrations/006_add_check_constraints.down.sql
+++ b/migrations/006_add_check_constraints.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users DROP CONSTRAINT IF EXISTS chk_users_revoked_after_created;
+ALTER TABLE users DROP CONSTRAINT IF EXISTS chk_users_superuser_team;
+ALTER TABLE databases DROP CONSTRAINT IF EXISTS chk_databases_status;

--- a/migrations/006_add_check_constraints.up.sql
+++ b/migrations/006_add_check_constraints.up.sql
@@ -1,0 +1,11 @@
+-- databases.status must be a known value
+ALTER TABLE databases ADD CONSTRAINT chk_databases_status
+  CHECK (status IN ('provisioning', 'ready', 'error', 'deleting', 'deleted'));
+
+-- Non-superusers must have a team
+ALTER TABLE users ADD CONSTRAINT chk_users_superuser_team
+  CHECK (is_superuser = TRUE OR team_id IS NOT NULL);
+
+-- Revocation must be after creation
+ALTER TABLE users ADD CONSTRAINT chk_users_revoked_after_created
+  CHECK (revoked_at IS NULL OR revoked_at >= created_at);


### PR DESCRIPTION
## Summary
- Add migration `006_add_check_constraints` with three CHECK constraints:
  - `chk_databases_status`: ensures `databases.status` is one of the known values (`provisioning`, `ready`, `error`, `deleting`, `deleted`)
  - `chk_users_superuser_team`: ensures non-superusers always have a `team_id`
  - `chk_users_revoked_after_created`: ensures `revoked_at` is never before `created_at`
- Reversible down migration drops all three constraints

## Test plan
- [ ] Apply migration against a database with existing data
- [ ] Verify constraint violations are rejected (e.g., inserting a user with `is_superuser=false` and `team_id=NULL`)
- [ ] Verify down migration cleanly removes all constraints

🤖 Generated with [Claude Code](https://claude.com/claude-code)