### PR TITLE
fix(api): eliminate N+1 query in user List handler

### DIFF
--- a/internal/api/handler/user.go
+++ b/internal/api/handler/user.go
@@ -148,12 +148,8 @@ func (h *UserHandler) List(w http.ResponseWriter, r *http.Request) {
 		if u.TeamID != nil {
 			tid := u.TeamID.String()
 			resp.TeamID = &tid
-			// Fetch team to get name and role
-			t, err := h.teamRepo.GetByID(r.Context(), *u.TeamID)
-			if err == nil {
-				resp.TeamName = &t.Name
-				resp.Role = &t.Role
-			}
+			resp.TeamName = u.TeamName
+			resp.Role = u.TeamRole
 		}
 		if u.RevokedAt != nil {
 			revoked := u.RevokedAt.UTC().Format("2006-01-02T15:04:05Z")

--- a/internal/auth/model.go
+++ b/internal/auth/model.go
@@ -16,6 +16,8 @@ type User struct {
 	ApiKeyHash   string
 	CreatedAt    time.Time
 	RevokedAt    *time.Time
+	TeamName     *string // transient, populated via JOIN in List query
+	TeamRole     *string // transient, populated via JOIN in List query
 }
 
 // Identity is stored in the request context after authentication.

--- a/internal/auth/postgres_repository.go
+++ b/internal/auth/postgres_repository.go
@@ -108,7 +108,8 @@ func (r *PostgresRepository) FindByPrefix(ctx context.Context, prefix string) ([
 func (r *PostgresRepository) List(ctx context.Context) ([]User, error) {
 	query := `
 		SELECT u.id, u.name, u.team_id, u.is_superuser, u.api_key_prefix,
-		       u.api_key_hash, u.created_at, u.revoked_at
+		       u.api_key_hash, u.created_at, u.revoked_at,
+		       t.name, t.role
 		FROM users u
 		LEFT JOIN teams t ON u.team_id = t.id
 		ORDER BY u.created_at ASC`
@@ -126,6 +127,7 @@ func (r *PostgresRepository) List(ctx context.Context) ([]User, error) {
 			&u.ID, &u.Name, &u.TeamID, &u.IsSuperuser,
 			&u.ApiKeyPrefix, &u.ApiKeyHash,
 			&u.CreatedAt, &u.RevokedAt,
+			&u.TeamName, &u.TeamRole,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scanning user row: %w", err)

--- a/tests/unit/api/handler/user_handler_test.go
+++ b/tests/unit/api/handler/user_handler_test.go
@@ -269,21 +269,16 @@ func TestUserList_WithTeamInfo(t *testing.T) {
 
 	teamID := uuid.New()
 	userID := uuid.New()
+	teamName := "ops"
+	teamRole := "platform"
 
-	teamRepo := &mockTeamRepo{
-		getByIDFn: func(_ context.Context, id uuid.UUID) (*team.Team, error) {
-			return &team.Team{
-				ID:   teamID,
-				Name: "ops",
-				Role: "platform",
-			}, nil
-		},
-	}
+	teamRepo := &mockTeamRepo{}
 	userRepo := &mockUserRepo{
 		listFn: func(_ context.Context) ([]auth.User, error) {
-			return []auth.User{
-				*sampleUser(userID, &teamID, false),
-			}, nil
+			u := sampleUser(userID, &teamID, false)
+			u.TeamName = &teamName
+			u.TeamRole = &teamRole
+			return []auth.User{*u}, nil
 		},
 	}
 	authSvc := auth.NewService(userRepo, teamRepo, 4)


### PR DESCRIPTION
## Summary
- Fix N+1 query in `GET /users`: the handler was calling `teamRepo.GetByID` per user to resolve team name and role
- Add transient `TeamName` and `TeamRole` fields to `auth.User` model
- Update `PostgresRepository.List` to select `t.name` and `t.role` from the existing `LEFT JOIN teams`
- Update `UserHandler.List` to use transient fields directly instead of per-user lookups
- Update unit tests to populate transient fields from mock, removing mock `teamRepo.GetByID` dependency from List tests

## Test plan
- [ ] Verify `GET /users` still returns `teamName` and `role` for team users
- [ ] Verify `GET /users` returns null `teamName`/`role` for superuser (no team)
- [ ] Verify all unit tests pass (`make test`)
- [ ] Verify lint passes (`make lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)