### PR TITLE
chore(rules): add data-model conventions

### DIFF
--- a/.claude/rules/data-model.md
+++ b/.claude/rules/data-model.md
@@ -1,0 +1,25 @@
+---
+globs:
+  - "migrations/**"
+  - "internal/database/**"
+  - "internal/*/repository.go"
+  - "internal/*/postgres_repository.go"
+  - "internal/api/handler/**"
+---
+
+# Data Model Conventions
+
+## Foreign Key Integrity
+- Every cross-table reference MUST use a UUID FK column with `REFERENCES ... ON DELETE {RESTRICT|CASCADE|SET NULL}`
+- Never use VARCHAR for cross-table references — store UUID, JOIN for display
+- New tables: verify all relationship columns have FK constraints
+
+## CHECK Constraints
+- Columns with known value sets (status, role) MUST have `CHECK (col IN (...))`
+- Business invariants MUST be enforced as CHECK constraints, not just application logic
+- Temporal invariants (e.g., `revoked_at >= created_at`) MUST have CHECK constraints
+
+## N+1 Query Prevention
+- List endpoints MUST NOT call single-record queries in a loop
+- Use JOINs to fetch related data in the List query itself
+- Add transient fields to models populated via JOIN — never loop GetByID


### PR DESCRIPTION
## Summary
- Add `.claude/rules/data-model.md` with conventions for FK integrity, CHECK constraints, and N+1 query prevention
- Targets migrations, database models, repositories, and handler files via YAML frontmatter globs
- Captures patterns from v0.4 review findings (owner_team FK, CHECK constraints, user list N+1)

## Test plan
- [x] No code changes, only a rules file addition
- [ ] CI should pass (lint, build, test, openapi validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)